### PR TITLE
Added exchangeName parameter to error handling ... 

### DIFF
--- a/src/Myxomatosis/Connection/Errors/IRabbitMessageErrorHandler.cs
+++ b/src/Myxomatosis/Connection/Errors/IRabbitMessageErrorHandler.cs
@@ -5,8 +5,8 @@ namespace Myxomatosis.Connection.Errors
 {
     public interface IRabbitMessageErrorHandler
     {
-        void Error(RabbitMessage message);
+        void Error(RabbitMessage message, string errorExchange = null);
 
-        void Error(RabbitMessage message, Exception exception);
+        void Error(RabbitMessage message, Exception exception, string errorExchange = null);
     }
 }

--- a/src/Myxomatosis/Connection/Errors/UnhandledErrorHandler.cs
+++ b/src/Myxomatosis/Connection/Errors/UnhandledErrorHandler.cs
@@ -9,7 +9,7 @@ namespace Myxomatosis.Connection.Errors
     {
         private readonly IRabbitPublisher _publisher;
         private readonly ISerializer _serializer;
-        private readonly string ErrorQueueName = "ErrorExchange";
+        private readonly string ErrorExchangeName = "ErrorExchange";
 
         #region Constructors
 
@@ -23,17 +23,17 @@ namespace Myxomatosis.Connection.Errors
 
         #region IRabbitMessageErrorHandler Members
 
-        public virtual void Error(RabbitMessage message)
+        public virtual void Error(RabbitMessage message, string errorExchange = null)
         {
             var errorMessage = new ErrorMessage
             {
                 Message = MessageDetails.FromRabbitMessage(message)
             };
 
-            _publisher.Publish(_serializer.Serialize(errorMessage), ErrorQueueName);
+            _publisher.Publish(_serializer.Serialize(errorMessage), errorExchange ?? ErrorExchangeName);
         }
 
-        public virtual void Error(RabbitMessage message, Exception exception)
+        public virtual void Error(RabbitMessage message, Exception exception, string errorExchange = null)
         {
             var errorMessage = new ErrorMessage
             {
@@ -41,7 +41,7 @@ namespace Myxomatosis.Connection.Errors
                 Exception = ExceptionDetails.FromException(exception)
             };
 
-            _publisher.Publish(_serializer.Serialize(errorMessage), ErrorQueueName);
+            _publisher.Publish(_serializer.Serialize(errorMessage), errorExchange ?? ErrorExchangeName);
         }
 
         #endregion IRabbitMessageErrorHandler Members

--- a/src/Myxomatosis/Connection/Message/IRabbitMessageModel.cs
+++ b/src/Myxomatosis/Connection/Message/IRabbitMessageModel.cs
@@ -6,9 +6,9 @@ namespace Myxomatosis.Connection.Message
     {
         void Acknowledge();
 
-        void Error();
+        void Error(string exchangeName = null);
 
-        void Error(Exception exception);
+        void Error(Exception exception, string exchangeName = null);
 
         void Reject();
     }

--- a/src/Myxomatosis/Connection/Message/RabbitMessage.cs
+++ b/src/Myxomatosis/Connection/Message/RabbitMessage.cs
@@ -39,16 +39,16 @@ namespace Myxomatosis.Connection.Message
             Channel.BasicAck(DeliveryTag, false);
         }
 
-        void IRabbitMessageModel.Error()
+        void IRabbitMessageModel.Error(string exchangeName)
         {
-            ErrorHandler.Error(this);
+            ErrorHandler.Error(this, exchangeName);
         }
 
-        void IRabbitMessageModel.Error(Exception exception)
+        void IRabbitMessageModel.Error(Exception exception, string exchangeName)
         {
             if (exception == null)
                 throw new ArgumentException("Expected a non-null Exception", "exception");
-            ErrorHandler.Error(this, exception);
+            ErrorHandler.Error(this, exception, exchangeName);
         }
 
         public void Reject()

--- a/src/Myxomatosis/ObservableRabbitMessageExtensions.cs
+++ b/src/Myxomatosis/ObservableRabbitMessageExtensions.cs
@@ -106,19 +106,19 @@ namespace Myxomatosis
                 }
             }
 
-            public void Error()
+            public void Error(string exchangeName = null)
             {
                 foreach (var rabbitMessageModel in _messageModels)
                 {
-                    rabbitMessageModel.Error();
+                    rabbitMessageModel.Error(exchangeName);
                 }
             }
 
-            public void Error(Exception exception)
+            public void Error(Exception exception, string exchangeName = null)
             {
                 foreach (var rabbitMessageModel in _messageModels)
                 {
-                    rabbitMessageModel.Error(exception);
+                    rabbitMessageModel.Error(exception, exchangeName);
                 }
             }
 


### PR DESCRIPTION
... methods to allow consumer to decide where error details should be published.

Had originally added requeue param on reject/nack to allow use of dead letter exchange config, but that wasn't adding any error messages.
